### PR TITLE
Call stableSnapTo when commiting a snapshot in multinode.

### DIFF
--- a/raft/multinode.go
+++ b/raft/multinode.go
@@ -109,6 +109,7 @@ func (g *groupState) commitReady(rd Ready) {
 	}
 	if !IsEmptySnap(rd.Snapshot) {
 		g.prevSnapi = rd.Snapshot.Metadata.Index
+		g.raft.raftLog.stableSnapTo(g.prevSnapi)
 	}
 	if len(rd.Entries) > 0 {
 		// TODO(bdarnell): stableTo(rd.Snapshot.Index) if any


### PR DESCRIPTION
@spencerkimball @cockroachdb/developers 

(This is currently only tested by an upcoming PR in the main cockroach repo)